### PR TITLE
Upgrade feedparser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ keywords = ["News", "RSS", "Scraping", "Data Mining"]
 
 [tool.poetry.dependencies]
 python = "^3.6"
-feedparser = "^5.2.1"
+feedparser = "^6.0.2"
 beautifulsoup4 = "^4.9.1"
 dateparser = "^0.7.6"
 requests = "^2.24.0"


### PR DESCRIPTION
* Currently the feedparser specified in the requirements does not work with Python 3.9.x due to this issue: https://github.com/kurtmckee/feedparser/pull/206
* Upgrade the feedparser so pygooglenews works with python 3.9.x